### PR TITLE
Feature/#46 게시판 생성 기능 구현

### DIFF
--- a/eb-study-templates-4week-backend/build.gradle
+++ b/eb-study-templates-4week-backend/build.gradle
@@ -1,38 +1,42 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '2.7.16'
-	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
+    id 'java'
+    id 'org.springframework.boot' version '2.7.16'
+    id 'io.spring.dependency-management' version '1.0.15.RELEASE'
 }
 
 group = 'com.ebsoft'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '11'
+    sourceCompatibility = '11'
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    //시큐리티 설치
+    implementation 'org.springframework.boot:spring-boot-starter-security'
 
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    annotationProcessor 'org.projectlombok:lombok'
 
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    //시큐리티 설치
+    testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/eb-study-templates-4week-backend/src/main/java/com/ebsoft/ebstudytemplates4weekbackend/domain/category/application/CategoryService.java
+++ b/eb-study-templates-4week-backend/src/main/java/com/ebsoft/ebstudytemplates4weekbackend/domain/category/application/CategoryService.java
@@ -1,0 +1,25 @@
+package com.ebsoft.ebstudytemplates4weekbackend.domain.category.application;
+
+import com.ebsoft.ebstudytemplates4weekbackend.domain.category.dao.CategoryRepository;
+import com.ebsoft.ebstudytemplates4weekbackend.domain.category.entity.Category;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CategoryService {
+
+  private final CategoryRepository categoryRepository;
+
+  /**
+   * 카테고리 모두 저장
+   */
+  @Transactional
+  public void saveCategories(List<Category> categories) {
+    categoryRepository.saveAll(categories);
+  }
+
+}

--- a/eb-study-templates-4week-backend/src/main/java/com/ebsoft/ebstudytemplates4weekbackend/domain/category/entity/Category.java
+++ b/eb-study-templates-4week-backend/src/main/java/com/ebsoft/ebstudytemplates4weekbackend/domain/category/entity/Category.java
@@ -1,13 +1,12 @@
 package com.ebsoft.ebstudytemplates4weekbackend.domain.category.entity;
 
-import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Table;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -18,15 +17,19 @@ import lombok.NoArgsConstructor;
 public class Category {
 
   public static final int MAX_NAME_LENGTH = 15;
-  
+
   //카테고리 id
   @Id
-  @GeneratedValue(strategy = IDENTITY)
   @Column(name = "category_id", nullable = false)
   private Long id;
 
   //카테고리 이름
   @Column(name = "category_name", nullable = false, length = MAX_NAME_LENGTH)
-  private Long name;
+  private String name;
 
+  @Builder
+  public Category(Long id, String name) {
+    this.id = id;
+    this.name = name;
+  }
 }

--- a/eb-study-templates-4week-backend/src/main/java/com/ebsoft/ebstudytemplates4weekbackend/domain/category/entity/CategoryType.java
+++ b/eb-study-templates-4week-backend/src/main/java/com/ebsoft/ebstudytemplates4weekbackend/domain/category/entity/CategoryType.java
@@ -1,0 +1,26 @@
+package com.ebsoft.ebstudytemplates4weekbackend.domain.category.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 카테고리 종류 ENUM
+ */
+@Getter
+@RequiredArgsConstructor
+public enum CategoryType {
+
+  JAVA(1, "JAVA"),
+  DATABASE(2, "DataBase"),
+  JAVASCRIPT(3, "JavaScript");
+
+  private final long id;
+  private final String name;
+
+  public Category toEntity() {
+    return Category.builder()
+        .id(this.id)
+        .name(this.name)
+        .build();
+  }
+}

--- a/eb-study-templates-4week-backend/src/main/java/com/ebsoft/ebstudytemplates4weekbackend/domain/file/dao/FileRepository.java
+++ b/eb-study-templates-4week-backend/src/main/java/com/ebsoft/ebstudytemplates4weekbackend/domain/file/dao/FileRepository.java
@@ -1,0 +1,8 @@
+package com.ebsoft.ebstudytemplates4weekbackend.domain.file.dao;
+
+import com.ebsoft.ebstudytemplates4weekbackend.domain.file.entity.File;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FileRepository extends JpaRepository<File, Long> {
+
+}

--- a/eb-study-templates-4week-backend/src/main/java/com/ebsoft/ebstudytemplates4weekbackend/domain/file/entity/File.java
+++ b/eb-study-templates-4week-backend/src/main/java/com/ebsoft/ebstudytemplates4weekbackend/domain/file/entity/File.java
@@ -1,0 +1,46 @@
+package com.ebsoft.ebstudytemplates4weekbackend.domain.file.entity;
+
+import static javax.persistence.FetchType.LAZY;
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import com.ebsoft.ebstudytemplates4weekbackend.domain.board.entity.Board;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+@Getter
+@Table(name = "t_file")
+public class File {
+
+  public static final int MAX_FILE_NAME_LENGTH = 512;
+  public static final int MAX_STORE_NAME_LENGTH = 512;
+
+  //파일 id
+  @Id
+  @GeneratedValue(strategy = IDENTITY)
+  @Column(name = "file_id", nullable = false)
+  private Long id;
+
+  //게시판 (N:1)
+  @ManyToOne(fetch = LAZY)
+  @JoinColumn(name = "board_id")
+  private Board board;
+
+  //업로드한 파일 이름
+  @Column(name = "file_name", nullable = false, length = MAX_FILE_NAME_LENGTH)
+  private String fileName;
+
+  //서버에서의 파일 이름
+  @Column(name = "store_name", nullable = false, length = MAX_STORE_NAME_LENGTH)
+  private String storeName;
+
+}

--- a/eb-study-templates-4week-backend/src/main/java/com/ebsoft/ebstudytemplates4weekbackend/global/config/security/SpringSecurity.java
+++ b/eb-study-templates-4week-backend/src/main/java/com/ebsoft/ebstudytemplates4weekbackend/global/config/security/SpringSecurity.java
@@ -1,0 +1,40 @@
+package com.ebsoft.ebstudytemplates4weekbackend.global.config.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ * 스프링 시큐리티 관련 설정
+ */
+@Configuration
+@EnableWebSecurity
+public class SpringSecurity {
+
+  /**
+   * 필터 체인
+   */
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    http
+        .cors().disable()    //cors방지
+        .csrf().disable()    //csrf방지
+        .formLogin().disable()  //기본 로그인 페이지 없애기
+        .headers().frameOptions().disable();
+    return http.build();
+  }
+
+  /**
+   * 비밀번호 인코딩 방식 정하기
+   *
+   * @return BCrypt 인코더 사용
+   */
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
+}

--- a/eb-study-templates-4week-backend/src/main/java/com/ebsoft/ebstudytemplates4weekbackend/global/init/DbInit.java
+++ b/eb-study-templates-4week-backend/src/main/java/com/ebsoft/ebstudytemplates4weekbackend/global/init/DbInit.java
@@ -1,0 +1,34 @@
+package com.ebsoft.ebstudytemplates4weekbackend.global.init;
+
+import com.ebsoft.ebstudytemplates4weekbackend.domain.category.application.CategoryService;
+import com.ebsoft.ebstudytemplates4weekbackend.domain.category.entity.Category;
+import com.ebsoft.ebstudytemplates4weekbackend.domain.category.entity.CategoryType;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class DbInit {
+
+  @Autowired
+  private CategoryService categoryService;
+
+  /**
+   * 지정된 카테고리들을 모두 미리 저장한다.
+   */
+  @PostConstruct
+  private void InitCategories() {
+    List<Category> categoryList = new ArrayList<>();
+    for (CategoryType categoryType : CategoryType.values()) {
+      categoryList.add(categoryType.toEntity());
+    }
+
+    categoryService.saveCategories(categoryList);
+
+    log.info("지정된 카테고리 저장 완료");
+  }
+}

--- a/eb-study-templates-4week-backend/src/main/resources/application.yml
+++ b/eb-study-templates-4week-backend/src/main/resources/application.yml
@@ -9,8 +9,8 @@ spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://localhost:3306/ebrainsoft_study?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
-    username: ebsoft
-    password: ebsoft
+    username: root
+    password: root
 
   jpa:
     hibernate:


### PR DESCRIPTION
## 🔥 Related Issue

close: #46 

## 📝 Description

다음과 같이 전역 예외 처리를 구현하였습니다.

`ErrorCode`로 원하는 예외 메시지 및 상태 코드를 Enum으로 쉽게 관리하여, 추가 및 수정에 용이하게 구현하였습니다.
`ErrorResponse`로 Response를 정형화하였습니다. 
`BusinessException`은 로직상 예외를 발생시켜야할 때, 사용하는 언체크 예외입니다.

`ExceptionAdvice`는 `@RestControllerAdvice`로 예외가 발생할 때, 위의 클래스를 이용하여, 
`"[{오류 명칭}] : {오류필드명}: {오류시지}"` 형식인 메시지와, 원하는 상태코드를 포함된 `ResponseEntity`를 반환합니다.

이로써, 예외가 발생하면, 원하는 메시지와 상태 코드로 보낼 수 있습니다.

## ⭐️ Review

