### PR TITLE
Feature/#47 전역 예외 처리 구현

### DIFF
--- a/eb-study-templates-4week-backend/src/main/java/com/ebsoft/ebstudytemplates4weekbackend/global/error/BusinessException.java
+++ b/eb-study-templates-4week-backend/src/main/java/com/ebsoft/ebstudytemplates4weekbackend/global/error/BusinessException.java
@@ -1,0 +1,28 @@
+package com.ebsoft.ebstudytemplates4weekbackend.global.error;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 로직에서 예외를 발생시킬 때 사용하는 언체크 예외
+ */
+@Getter
+public class BusinessException extends RuntimeException {
+
+  //오류 발생 부분의 값. 명확하게 없으면 Null.
+  private final String invalidValue;
+  //오류 필드명.
+  private final String fieldName;
+  //오류 상태 코드.
+  private final HttpStatus httpStatus;
+  //오류 메시지
+  private final String message;
+
+  public BusinessException(Object invalidValue, String fieldName, ErrorCode errorCode) {
+    super(errorCode.getMessage());
+    this.invalidValue = invalidValue != null ? invalidValue.toString() : null;
+    this.fieldName = fieldName;
+    this.httpStatus = errorCode.getHttpStatus();
+    this.message = errorCode.getMessage();
+  }
+}

--- a/eb-study-templates-4week-backend/src/main/java/com/ebsoft/ebstudytemplates4weekbackend/global/error/ErrorCode.java
+++ b/eb-study-templates-4week-backend/src/main/java/com/ebsoft/ebstudytemplates4weekbackend/global/error/ErrorCode.java
@@ -1,0 +1,21 @@
+package com.ebsoft.ebstudytemplates4weekbackend.global.error;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 오류 메시지와 상태를 쉽게 추가하기 위한 Enum
+ */
+@Getter
+public enum ErrorCode {
+  ;
+  //오류 메시지
+  private final String message;
+  //오류 상태코드
+  private final HttpStatus httpStatus;
+
+  ErrorCode(String message, HttpStatus httpStatus) {
+    this.message = message;
+    this.httpStatus = httpStatus;
+  }
+}

--- a/eb-study-templates-4week-backend/src/main/java/com/ebsoft/ebstudytemplates4weekbackend/global/error/ErrorResponse.java
+++ b/eb-study-templates-4week-backend/src/main/java/com/ebsoft/ebstudytemplates4weekbackend/global/error/ErrorResponse.java
@@ -1,0 +1,19 @@
+package com.ebsoft.ebstudytemplates4weekbackend.global.error;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 포맷팅된 에러 메시지 담을 Response DTO
+ */
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ErrorResponse {
+
+  private final String message;
+
+  public static ErrorResponse from(String message) {
+    return new ErrorResponse(message);
+  }
+}

--- a/eb-study-templates-4week-backend/src/main/java/com/ebsoft/ebstudytemplates4weekbackend/global/error/ExceptionAdvice.java
+++ b/eb-study-templates-4week-backend/src/main/java/com/ebsoft/ebstudytemplates4weekbackend/global/error/ExceptionAdvice.java
@@ -1,0 +1,69 @@
+package com.ebsoft.ebstudytemplates4weekbackend.global.error;
+
+import java.util.stream.Collectors;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * 전역 예외 처리
+ */
+@RestControllerAdvice
+public class ExceptionAdvice {
+
+  /**
+   * BindException 오류가 발생할 때, Response 처리.
+   *
+   * @param e BindException
+   * @return Response 내용
+   */
+  @ExceptionHandler(BindException.class)
+  public ResponseEntity<ErrorResponse> bindException(BindException e) {
+    String errorMessage = getErrorMessage(e);
+
+    return ResponseEntity.badRequest().body(ErrorResponse.from(errorMessage));
+  }
+
+  /**
+   * BusinessException 오류가 발생할 때, Response 처리.
+   *
+   * @param e BusinessException
+   * @return Response 내용
+   */
+  @ExceptionHandler(BusinessException.class)
+  public ResponseEntity<ErrorResponse> businessException(BusinessException e) {
+    String errorMessage = getErrorMessage(e.getInvalidValue(), e.getFieldName(), e.getMessage());
+
+    return ResponseEntity.status(e.getHttpStatus()).body(ErrorResponse.from(errorMessage));
+  }
+
+  /**
+   * BindingException의 bindingResult 분석 후, 오류 메시지 생성
+   *
+   * @param e BindException
+   * @return 포멧팅된 오류 메시지
+   */
+  private static String getErrorMessage(BindException e) {
+    BindingResult bindingResult = e.getBindingResult();
+
+    return bindingResult.getFieldErrors().stream()
+        .map(fieldError ->
+            getErrorMessage(
+                (String) fieldError.getRejectedValue(),
+                fieldError.getField(),
+                fieldError.getDefaultMessage()
+            )
+        )
+        .collect(Collectors.joining(", "));
+  }
+
+  /**
+   * 메시지 포멧팅
+   */
+  public static String getErrorMessage(String invalidValue, String errorField,
+      String errorMessage) {
+    return String.format("[%s] %s: %s", invalidValue, errorField, errorMessage);
+  }
+}


### PR DESCRIPTION
## 🔥 Related Issue

close: #47 

## 📝 Description

다음과 같이 전역 예외 처리를 구현하였습니다.

`ErrorCode`로 원하는 예외 메시지 및 상태 코드를 Enum으로 쉽게 관리하여, 추가 및 수정에 용이하게 구현하였습니다.
`ErrorResponse`로 Response를 정형화하였습니다. 
`BusinessException`은 로직상 예외를 발생시켜야할 때, 사용하는 언체크 예외입니다.

`ExceptionAdvice`는 `@RestControllerAdvice`로 예외가 발생할 때, 위의 클래스를 이용하여, 
`"[{오류 명칭}] : {오류필드명}: {오류시지}"` 형식인 메시지와, 원하는 상태코드를 포함된 `ResponseEntity`를 반환합니다.

이로써, 예외가 발생하면, 원하는 메시지와 상태 코드로 보낼 수 있습니다.

## ⭐️ Review

